### PR TITLE
Add basic(draft) functionality to users-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,20 @@ services:
     container_name: user-server
     depends_on:
       - mongodb
+      - postgres
     env_file:
       - ./userService/java.env
     environment:
       SERVER_PORT: 8080
+      POSTGRES_DATASOURCE_URL: jdbc:postgresql://postgres:5432/high_load_db
+      POSTGRES_PASSWORD: example
+      POSTGRES_USERNAME: postgres
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin_password
+      ADMIN_EMAIL: admin@example.com
+      JWT_SECRET_KEY: "LJQTjyGnd3oOiVAMssQgG62qDv6xgOdXbRPFKGzWqfU=" #base64
+      JWT_EXPIRATION_TIME: 3600000 # 1 hour
+      JWT_REFRESH_EXPIRATION_TIME: 86400000 # 1 day
       MONGODB_HOST: mongodb
       MONGODB_PORT: 27017
       MONGO_DB: highLoadDb

--- a/userService/pom.xml
+++ b/userService/pom.xml
@@ -34,9 +34,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
 		<dependency>
@@ -44,15 +50,66 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.4</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+			<version>11.7.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+			<version>11.7.0</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/userService/src/main/java/ua/edu/ukma/users/config/AdminInitializer.java
+++ b/userService/src/main/java/ua/edu/ukma/users/config/AdminInitializer.java
@@ -1,0 +1,42 @@
+package ua.edu.ukma.users.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import ua.edu.ukma.users.model.User;
+import ua.edu.ukma.users.model.UserRole;
+import ua.edu.ukma.users.repository.UserRepository;
+
+@Configuration
+@RequiredArgsConstructor
+public class AdminInitializer {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${admin.username}")
+    private String adminUsername;
+
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    @Value("${admin.email}")
+    private String adminEmail;
+
+    @Bean
+    public CommandLineRunner createAdminUser() {
+        return args -> {
+            if (!userRepository.existsByUsername(adminUsername)) {
+                User adminUser = new User();
+                adminUser.setUsername(adminUsername);
+                adminUser.setEmail(adminEmail);
+                adminUser.setPassword(passwordEncoder.encode(adminPassword));
+                adminUser.setRole(UserRole.ROLE_ADMIN);
+                userRepository.save(adminUser);
+            }
+        };
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/config/SecurityConfig.java
+++ b/userService/src/main/java/ua/edu/ukma/users/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package ua.edu.ukma.users.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import ua.edu.ukma.users.filter.JwtAuthenticationFilter;
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final UserDetailsService userDetailsService;
+    private final JwtAuthenticationFilter jwtAuthFilter;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/controller/AuthController.java
+++ b/userService/src/main/java/ua/edu/ukma/users/controller/AuthController.java
@@ -1,0 +1,33 @@
+package ua.edu.ukma.users.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ua.edu.ukma.users.dto.auth.JwtAuthenticationResponse;
+import ua.edu.ukma.users.dto.auth.RefreshTokenRequest;
+import ua.edu.ukma.users.dto.auth.SignInRequest;
+import ua.edu.ukma.users.dto.auth.SignUpRequest;
+import ua.edu.ukma.users.service.AuthService;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<JwtAuthenticationResponse> signup(@Valid @RequestBody SignUpRequest request) {
+        return ResponseEntity.ok(authService.signup(request));
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<JwtAuthenticationResponse> signin(@Valid @RequestBody SignInRequest request) {
+        return ResponseEntity.ok(authService.signin(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtAuthenticationResponse> refresh(@Valid @RequestBody RefreshTokenRequest request) {
+        return ResponseEntity.ok(authService.refreshToken(request.getRefreshToken()));
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/controller/UserController.java
+++ b/userService/src/main/java/ua/edu/ukma/users/controller/UserController.java
@@ -1,0 +1,40 @@
+package ua.edu.ukma.users.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import ua.edu.ukma.users.dto.user.UserProfileResponse;
+import ua.edu.ukma.users.model.User;
+import ua.edu.ukma.users.service.UserService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserProfileResponse> getUserById(@PathVariable UUID id) {
+        String currentUsername = SecurityContextHolder.getContext().getAuthentication().getName();
+        User authenticatedUser = userService.findByUsernameOrThrow(currentUsername);
+
+        if (!authenticatedUser.getId().equals(id)) {
+            return ResponseEntity.status(403).build();
+        }
+
+        User requestedUser = userService.findByIdOrThrow(id);
+
+        return ResponseEntity.ok(
+                UserProfileResponse.builder()
+                        .id(requestedUser.getId())
+                        .username(requestedUser.getUsername())
+                        .email(requestedUser.getEmail())
+                        .role(requestedUser.getRole().name())
+                        .build()
+        );
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/dto/auth/JwtAuthenticationResponse.java
+++ b/userService/src/main/java/ua/edu/ukma/users/dto/auth/JwtAuthenticationResponse.java
@@ -1,0 +1,18 @@
+package ua.edu.ukma.users.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtAuthenticationResponse {
+    private UUID id;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/userService/src/main/java/ua/edu/ukma/users/dto/auth/RefreshTokenRequest.java
+++ b/userService/src/main/java/ua/edu/ukma/users/dto/auth/RefreshTokenRequest.java
@@ -1,0 +1,16 @@
+package ua.edu.ukma.users.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequest {
+    @NotBlank(message = "Refresh token is required")
+    private String refreshToken;
+}

--- a/userService/src/main/java/ua/edu/ukma/users/dto/auth/SignInRequest.java
+++ b/userService/src/main/java/ua/edu/ukma/users/dto/auth/SignInRequest.java
@@ -1,0 +1,19 @@
+package ua.edu.ukma.users.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignInRequest {
+    @NotBlank(message = "Username is required")
+    private String username;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+}

--- a/userService/src/main/java/ua/edu/ukma/users/dto/auth/SignUpRequest.java
+++ b/userService/src/main/java/ua/edu/ukma/users/dto/auth/SignUpRequest.java
@@ -1,0 +1,27 @@
+package ua.edu.ukma.users.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequest {
+    @NotBlank(message = "Username is required")
+    @Size(min = 4, max = 50, message = "Username must be between 4 and 50 characters")
+    private String username;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email should be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+}

--- a/userService/src/main/java/ua/edu/ukma/users/dto/user/UserProfileResponse.java
+++ b/userService/src/main/java/ua/edu/ukma/users/dto/user/UserProfileResponse.java
@@ -1,0 +1,19 @@
+package ua.edu.ukma.users.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponse {
+    private UUID id;
+    private String username;
+    private String email;
+    private String role;
+}

--- a/userService/src/main/java/ua/edu/ukma/users/exception/GlobalExceptionHandler.java
+++ b/userService/src/main/java/ua/edu/ukma/users/exception/GlobalExceptionHandler.java
@@ -1,0 +1,91 @@
+package ua.edu.ukma.users.exception;
+
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.security.WeakKeyException;
+import io.jsonwebtoken.io.DecodingException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<String> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        return ResponseEntity
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body("HTTP method not supported for this endpoint.");
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Map<String, String>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "Invalid UUID format for user ID");
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<Map<String, String>> handleUserAlreadyExistsException(UserAlreadyExistsException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler({InvalidCredentialsException.class, BadCredentialsException.class})
+    public ResponseEntity<Map<String, String>> handleAuthenticationException(RuntimeException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "Invalid username or password");
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler({InvalidJwtTokenException.class, ExpiredJwtException.class, MalformedJwtException.class, SignatureException.class})
+    public ResponseEntity<Map<String, String>> handleJwtException(Exception ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "Invalid or expired JWT token");
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(TokenRefreshException.class)
+    public ResponseEntity<Map<String, String>> handleTokenRefreshException(TokenRefreshException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler({DecodingException.class, WeakKeyException.class})
+    public ResponseEntity<Map<String, String>> handleJwtConfigurationException(Exception ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "JWT configuration error: " + ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenericException(Exception ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "An unexpected error occurred");
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/exception/InvalidCredentialsException.java
+++ b/userService/src/main/java/ua/edu/ukma/users/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package ua.edu.ukma.users.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/exception/InvalidJwtTokenException.java
+++ b/userService/src/main/java/ua/edu/ukma/users/exception/InvalidJwtTokenException.java
@@ -1,0 +1,7 @@
+package ua.edu.ukma.users.exception;
+
+public class InvalidJwtTokenException extends RuntimeException {
+    public InvalidJwtTokenException(String message) {
+        super(message);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/exception/TokenRefreshException.java
+++ b/userService/src/main/java/ua/edu/ukma/users/exception/TokenRefreshException.java
@@ -1,0 +1,7 @@
+package ua.edu.ukma.users.exception;
+
+public class TokenRefreshException extends RuntimeException {
+    public TokenRefreshException(String message) {
+        super(message);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/exception/UserAlreadyExistsException.java
+++ b/userService/src/main/java/ua/edu/ukma/users/exception/UserAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package ua.edu.ukma.users.exception;
+
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/exception/UserNotFoundException.java
+++ b/userService/src/main/java/ua/edu/ukma/users/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package ua.edu.ukma.users.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/filter/JwtAuthenticationFilter.java
+++ b/userService/src/main/java/ua/edu/ukma/users/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package ua.edu.ukma.users.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import ua.edu.ukma.users.service.JwtService;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String username;
+        
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        
+        jwt = authHeader.substring(7);
+        
+        try {
+            username = jwtService.extractUsername(jwt);
+            
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+                
+                if (jwtService.isTokenValid(jwt, userDetails)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+                    
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+        } catch (ExpiredJwtException e) {
+            logger.warn("JWT token expired: {}", e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"JWT token expired\"}");
+            return;
+        } catch (Exception e) {
+            logger.error("Error processing JWT token", e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"Invalid JWT token\"}");
+            return;
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/model/User.java
+++ b/userService/src/main/java/ua/edu/ukma/users/model/User.java
@@ -1,0 +1,44 @@
+package ua.edu.ukma.users.model;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Data
+@NoArgsConstructor
+@Table(name = "users")
+public class User implements UserDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Size(min = 4, max = 50, message = "Username must be between 4 and 50 characters")
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+}

--- a/userService/src/main/java/ua/edu/ukma/users/model/UserRole.java
+++ b/userService/src/main/java/ua/edu/ukma/users/model/UserRole.java
@@ -1,0 +1,6 @@
+package ua.edu.ukma.users.model;
+
+public enum UserRole {
+    ROLE_ADMIN,
+    ROLE_USER;
+}

--- a/userService/src/main/java/ua/edu/ukma/users/repository/UserRepository.java
+++ b/userService/src/main/java/ua/edu/ukma/users/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package ua.edu.ukma.users.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ua.edu.ukma.users.model.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+    boolean existsByUsername(String username);
+    void deleteByUsername(String username);
+}

--- a/userService/src/main/java/ua/edu/ukma/users/service/AuthService.java
+++ b/userService/src/main/java/ua/edu/ukma/users/service/AuthService.java
@@ -1,0 +1,100 @@
+package ua.edu.ukma.users.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import ua.edu.ukma.users.dto.auth.JwtAuthenticationResponse;
+import ua.edu.ukma.users.dto.auth.SignInRequest;
+import ua.edu.ukma.users.dto.auth.SignUpRequest;
+import ua.edu.ukma.users.exception.InvalidCredentialsException;
+import ua.edu.ukma.users.exception.InvalidJwtTokenException;
+import ua.edu.ukma.users.exception.TokenRefreshException;
+import ua.edu.ukma.users.exception.UserAlreadyExistsException;
+import ua.edu.ukma.users.model.User;
+import ua.edu.ukma.users.model.UserRole;
+import ua.edu.ukma.users.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+
+    public JwtAuthenticationResponse signup(SignUpRequest request) {
+        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+            throw new UserAlreadyExistsException("Username is already taken");
+        }
+
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new UserAlreadyExistsException("Email is already registered");
+        }
+
+        var user = new User();
+        user.setUsername(request.getUsername());
+        user.setEmail(request.getEmail());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setRole(UserRole.ROLE_USER);
+        userRepository.save(user);
+
+        var jwt = jwtService.generateToken(user);
+        var refresh = jwtService.generateRefreshToken(user);
+
+        return JwtAuthenticationResponse.builder()
+                .id(user.getId())
+                .accessToken(jwt)
+                .refreshToken(refresh)
+                .build();
+    }
+
+    public JwtAuthenticationResponse signin(SignInRequest request) {
+        try {
+            authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            request.getUsername(),
+                            request.getPassword()
+                    )
+            );
+        } catch (BadCredentialsException e) {
+            throw new InvalidCredentialsException("Invalid username or password");
+        }
+
+        var user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new InvalidCredentialsException("Invalid username or password"));
+
+        var jwt = jwtService.generateToken(user);
+        var refresh = jwtService.generateRefreshToken(user);
+
+        return JwtAuthenticationResponse.builder()
+                .id(user.getId())
+                .accessToken(jwt)
+                .refreshToken(refresh)
+                .build();
+    }
+
+    public JwtAuthenticationResponse refreshToken(String refreshToken) {
+        try {
+            String username = jwtService.extractUsername(refreshToken);
+            var user = userRepository.findByUsername(username)
+                    .orElseThrow(() -> new TokenRefreshException("Invalid refresh token"));
+
+            if (!jwtService.isTokenValid(refreshToken, user)) {
+                throw new TokenRefreshException("Refresh token is expired");
+            }
+
+            var newAccessToken = jwtService.generateToken(user);
+
+            return JwtAuthenticationResponse.builder()
+                    .id(user.getId())
+                    .accessToken(newAccessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        } catch (Exception e) {
+            throw new InvalidJwtTokenException("Failed to process refresh token: " + e.getMessage());
+        }
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/service/CustomUserDetailsService.java
+++ b/userService/src/main/java/ua/edu/ukma/users/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package ua.edu.ukma.users.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import ua.edu.ukma.users.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/service/JwtService.java
+++ b/userService/src/main/java/ua/edu/ukma/users/service/JwtService.java
@@ -1,0 +1,95 @@
+package ua.edu.ukma.users.service;
+
+import java.util.*;
+import java.util.function.Function;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import ua.edu.ukma.users.model.User;
+
+import javax.crypto.SecretKey;
+
+@Component
+public class JwtService {
+
+    @Value("${security.jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${security.jwt.expiration-time}")
+    private long jwtExpiration;
+
+    @Value("${security.jwt.refresh-expiration-time}")
+    private long refreshExpiration;
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        if (userDetails instanceof User customUser) {
+            claims.put("id", customUser.getId());
+            claims.put("email", customUser.getEmail());
+            claims.put("role", customUser.getRole());
+        }
+        return generateToken(claims, userDetails, jwtExpiration);
+    }
+
+    public String generateRefreshToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails, refreshExpiration);
+    }
+
+    private String generateToken(Map<String, Object> claims, UserDetails userDetails, long expiration) {
+        return Jwts.builder()
+                .claims(claims)
+                .subject(userDetails.getUsername())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSignInKey())
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> resolver) {
+        final Claims claims = extractAllClaims(token);
+        return resolver.apply(claims);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSignInKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private SecretKey getSignInKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String resolveToken(HttpServletRequest req) {
+        String header = req.getHeader("Authorization");
+        return (header != null && header.startsWith("Bearer ")) ? header.substring(7) : null;
+    }
+}

--- a/userService/src/main/java/ua/edu/ukma/users/service/UserService.java
+++ b/userService/src/main/java/ua/edu/ukma/users/service/UserService.java
@@ -1,0 +1,68 @@
+package ua.edu.ukma.users.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import ua.edu.ukma.users.exception.UserNotFoundException;
+import ua.edu.ukma.users.model.User;
+import ua.edu.ukma.users.model.UserRole;
+import ua.edu.ukma.users.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public Optional<User> findByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+
+    public User findByUsernameOrThrow(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException("User not found with username: " + username));
+    }
+
+    public Optional<User> findById(UUID id) {
+        return userRepository.findById(id);
+    }
+
+    public User findByIdOrThrow(UUID id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException("User not found with ID: " + id));
+    }
+
+    public List<User> findAll() {
+        return userRepository.findAll();
+    }
+
+    public boolean existsByUsername(String username) {
+        return userRepository.existsByUsername(username);
+    }
+
+    public User createUser(String username, String email, String rawPassword, UserRole role) {
+        User user = new User();
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setPassword(passwordEncoder.encode(rawPassword));
+        user.setRole(role);
+        return userRepository.save(user);
+    }
+
+    public User updateUser(User user) {
+        return userRepository.save(user);
+    }
+
+    public void deleteByUsername(String username) {
+        userRepository.deleteByUsername(username);
+    }
+
+    public void deleteById(UUID id) {
+        userRepository.deleteById(id);
+    }
+}

--- a/userService/src/main/resources/application.yml
+++ b/userService/src/main/resources/application.yml
@@ -1,6 +1,26 @@
 spring:
   application:
     name: users
+  datasource:
+    url: ${POSTGRES_DATASOURCE_URL}
+    username: ${POSTGRES_USERNAME:postgres}
+    password: ${POSTGRES_PASSWORD:password}
+    driver-class-name: org.postgresql.Driver
+  flyway.enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+admin:
+  username: ${ADMIN_USERNAME:admin}
+  password: ${ADMIN_PASSWORD:admin_password}
+  email: ${ADMIN_EMAIL:admin@example.com}
+
+security:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+    expiration-time: ${JWT_EXPIRATION_TIME:3600000} # 1 hour
+    refresh-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME:86400000} # 1 day
 
 springdoc:
   swagger-ui:

--- a/userService/src/main/resources/db/migration/V1__0_init_users_table.sql
+++ b/userService/src/main/resources/db/migration/V1__0_init_users_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE users
+(
+    id       UUID         NOT NULL,
+    username VARCHAR(50)  NOT NULL,
+    email    VARCHAR(255) NOT NULL,
+    password VARCHAR(255),
+    role     VARCHAR(255) NOT NULL,
+    CONSTRAINT pk_users PRIMARY KEY (id)
+);
+
+ALTER TABLE users
+    ADD CONSTRAINT uc_users_email UNIQUE (email);
+
+ALTER TABLE users
+    ADD CONSTRAINT uc_users_username UNIQUE (username);


### PR DESCRIPTION
Added logic for authorization with JWT token.

Added endpoints:
    - POST /api/v1/auth/signup - registration of a new user
    - POST /api/v1/auth/signin - login with username and password
    - POST /api/v1/auth/refresh - refresh jwt access token after expiration time
    - GET /api/v1/users/{UUID} - get information about an authorized user

The user with ROLE_ADMIN is created when the service is initialized.